### PR TITLE
Swipe fast and slow

### DIFF
--- a/Sencha/Actions/SenchaSwipeActions.swift
+++ b/Sencha/Actions/SenchaSwipeActions.swift
@@ -4,6 +4,7 @@ import EarlGrey
 public protocol SenchaSwipeActions: EarlGreyHumanizer {
 
     func swipe(_ matcher: Matcher, inDirection direction: SenchaDirection, file: StaticString, line: UInt)
+    func swipeFast(_ matcher: Matcher, inDirection direction: SenchaDirection, file: StaticString, line: UInt)
 }
 
 public extension SenchaSwipeActions {
@@ -16,6 +17,17 @@ public extension SenchaSwipeActions {
             line: line
         ).perform(
             grey_swipeSlowInDirection(direction.toGREYDirection())
+        )
+    }
+
+    func swipeFast(_ matcher: Matcher, inDirection direction: SenchaDirection,file: StaticString = #file, line: UInt = #line) {
+
+        select(
+            matcher,
+            file: file,
+            line: line
+        ).perform(
+            grey_swipeFastInDirection(direction.toGREYDirection())
         )
     }
 }


### PR DESCRIPTION
Added a `swipeFast` utility method to use the grey matcher `grey_swipeFastInDirection` .

As we already have a `swipe` method, which uses the swipeSlow grey matcher, I didn't want to break the API compatibility so haven't modified that one and just added a new method.

Alternatively we could add a generic swipe method with options `fast` and `slow` and deprecate the current swipe method.

I'm open to suggestions.