### PR TITLE
Cherry picked back button fix in ios14 from tech/ios14

### DIFF
--- a/ExampleProject/DetailViewController.swift
+++ b/ExampleProject/DetailViewController.swift
@@ -24,5 +24,6 @@ class DetailViewController: UIViewController {
         switchOn.accessibilityIdentifier = AccessibilityID.switchOn
         slider.accessibilityIdentifier = AccessibilityID.slider
         datePicker.accessibilityIdentifier = AccessibilityID.datePicker
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .action, target: nil, action: nil)
     }
 }

--- a/Sencha/Actions/SenchaTapActions.swift
+++ b/Sencha/Actions/SenchaTapActions.swift
@@ -21,9 +21,14 @@ public extension SenchaTapActions {
     }
 
     func tapBackButton(file: StaticString = #file, line: UInt = #line) {
-
+        var backButtonMatcher: Matcher
+        if #available(iOS 14, *) {
+            backButtonMatcher = .allOf([.descendant(.class(NSClassFromString("_UINavigationBarContentView")!)), .firstElement])
+        } else {
+            backButtonMatcher = .class(NSClassFromString("_UIBackButtonContainerView")!)
+        }
         select(
-            .class(NSClassFromString("_UIBackButtonContainerView")!),
+            backButtonMatcher,
             file: file,
             line: line
         ).perform(


### PR DESCRIPTION
We lost this fix in the revert of tech/ios14!

> "_UIBackButtonContainerView" is no longer available on iOS 14, since there is no precise way to identify the back button, we'll trust that the back button is the leftmost(first) descendant of "_UINavigationBarContentView"