### PR TITLE
[Move to KIF] Update tap actions

### DIFF
--- a/ExampleProject/DetailViewController.swift
+++ b/ExampleProject/DetailViewController.swift
@@ -12,7 +12,7 @@ class DetailViewController: UIViewController, UITextFieldDelegate {
     struct AccessibilityID {
 
         static let textField = "DetailViewController.textField"
-        static let switchOn = "DetailViewController.switchOn"
+        static let `switch` = "DetailViewController.switch"
         static let slider = "DetailViewController.slider"
         static let datePicker = "DetailViewController.datePicker"
         static let hiddenLabel = "DetailViewController.hiddenLabel"
@@ -24,7 +24,7 @@ class DetailViewController: UIViewController, UITextFieldDelegate {
         title = "Detail"
         textField.delegate = self
         textField.accessibilityIdentifier = AccessibilityID.textField
-        switchOn.accessibilityIdentifier = AccessibilityID.switchOn
+        switchOn.accessibilityIdentifier = AccessibilityID.switch
         slider.accessibilityIdentifier = AccessibilityID.slider
         datePicker.accessibilityIdentifier = AccessibilityID.datePicker
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .action, target: nil, action: nil)

--- a/ExampleProject/MainViewController.swift
+++ b/ExampleProject/MainViewController.swift
@@ -24,7 +24,7 @@ class MainViewController: UIViewController, UITableViewDelegate, UITableViewData
     @IBAction func editButtonPressed(_ sender: Any) {
         
         sectionTitle = sectionTitle == "Normal Mode" ? "Edit Mode" : "Normal Mode"
-        tableView.reloadData()
+        tableView?.reloadData()
     }
 
     func clearTableView() {

--- a/ExampleProjectTests/DetailViewShould.swift
+++ b/ExampleProjectTests/DetailViewShould.swift
@@ -47,11 +47,11 @@ class ViewDetailShould: XCTestCase {
     }
 
     func test_show_a_switch_with_on_state_and_turn_onto_off_state() {
-        assertSwitchIsOn(.accessibilityID(DetailViewController.AccessibilityID.switchOn))
+        assertSwitchIsOn(.accessibilityID(DetailViewController.AccessibilityID.switch))
 
-        tap(.accessibilityID(DetailViewController.AccessibilityID.switchOn))
+        setSwitch(with: .accessibilityID(DetailViewController.AccessibilityID.switch), toOn: false)
 
-        assertSwitchIsOff(.accessibilityID(DetailViewController.AccessibilityID.switchOn))
+        assertSwitchIsOff(.accessibilityID(DetailViewController.AccessibilityID.switch))
     }
     
     func test_clear_text_from_a_filled_text_field() {

--- a/ExampleProjectTests/MainViewShould.swift
+++ b/ExampleProjectTests/MainViewShould.swift
@@ -62,7 +62,7 @@ class MainViewShould: XCTestCase {
 
         tap(.text("12"), inScrollableElementWith: TABLE_VIEW_MATCHER)
         assertVisible(.text("Detail"))
-        tapBackButton()
+        tap(.accessibilityLabel("Sencha Example"))
 
         assertVisible(.text("Sencha Example"))
     }

--- a/Sencha/Actions/SenchaSwitchActions.swift
+++ b/Sencha/Actions/SenchaSwitchActions.swift
@@ -1,0 +1,21 @@
+import Foundation
+import KIF
+
+public protocol SenchaSwitchActions {
+    func setSwitch(with matcher: Matcher, toOn: Bool, file: StaticString, line: UInt)
+}
+
+extension XCTestCase: SenchaSwitchActions {
+    public func setSwitch(with matcher: Matcher, toOn: Bool, file: StaticString = #file, line: UInt = #line) {
+        switch matcher {
+        case .text(let text):
+            tester().setOn(toOn, forSwitchWithAccessibilityLabel: text)
+        case .accessibilityLabel(let label):
+            tester().setOn(toOn, forSwitchWithAccessibilityLabel: label)
+        case .accessibilityID(let accessibilityID):
+            tester().setOn(toOn, forSwitchWithAccessibilityIdentifier: accessibilityID)
+        default:
+            unsupportedTest(file: file, line: line)
+        }
+    }
+}

--- a/Sencha/Actions/SenchaTapActions.swift
+++ b/Sencha/Actions/SenchaTapActions.swift
@@ -1,38 +1,21 @@
 import Foundation
-import EarlGrey
+import KIF
 
 public protocol SenchaTapActions: EarlGreyHumanizer {
-    
     func tap(_ matcher: Matcher, file: StaticString, line: UInt)
-    func tapBackButton(file: StaticString, line: UInt)
 }
 
-public extension SenchaTapActions {
-        
-    func tap(_ matcher: Matcher, file: StaticString = #file, line: UInt = #line) {
-        
-        select(
-            matcher,
-            file: file,
-            line: line
-        ).perform(
-            grey_tap()
-        )
-    }
-
-    func tapBackButton(file: StaticString = #file, line: UInt = #line) {
-        var backButtonMatcher: Matcher
-        if #available(iOS 14, *) {
-            backButtonMatcher = .allOf([.descendant(.class(NSClassFromString("_UINavigationBarContentView")!)), .firstElement])
-        } else {
-            backButtonMatcher = .class(NSClassFromString("_UIBackButtonContainerView")!)
+extension XCTestCase: SenchaTapActions {
+    public func tap(_ matcher: Matcher, file: StaticString = #file, line: UInt = #line) {
+        switch matcher {
+        case .text(let text):
+            tester().tapView(withAccessibilityLabel: text)
+        case .accessibilityLabel(let label):
+            tester().tapView(withAccessibilityLabel: label)
+        case .accessibilityID(let accessibilityID):
+            tester().tapView(withAccessibilityIdentifier: accessibilityID)
+        default:
+            unsupportedTest(file: file, line: line)
         }
-        select(
-            backButtonMatcher,
-            file: file,
-            line: line
-        ).perform(
-            grey_tap()
-        )
     }
 }

--- a/Sencha/Actions/SenchaTapActions.swift
+++ b/Sencha/Actions/SenchaTapActions.swift
@@ -7,15 +7,6 @@ public protocol SenchaTapActions: EarlGreyHumanizer {
 
 extension XCTestCase: SenchaTapActions {
     public func tap(_ matcher: Matcher, file: StaticString = #file, line: UInt = #line) {
-        switch matcher {
-        case .text(let text):
-            tester().tapView(withAccessibilityLabel: text)
-        case .accessibilityLabel(let label):
-            tester().tapView(withAccessibilityLabel: label)
-        case .accessibilityID(let accessibilityID):
-            tester().tapView(withAccessibilityIdentifier: accessibilityID)
-        default:
-            unsupportedTest(file: file, line: line)
-        }
+        tester().tap(nil, in: findView(with: matcher))
     }
 }


### PR DESCRIPTION
Updated tap actions to use KIF

UISwitch needs a separate implementation since KIF's `tapView` doesn't work with it.