### PR TITLE
[Fix] Use the correct method to match accesibilityIDs

### DIFF
--- a/Sencha/Assertions/SenchaAssertion.swift
+++ b/Sencha/Assertions/SenchaAssertion.swift
@@ -25,7 +25,7 @@ extension XCTestCase: SenchaAssertion {
         case .accessibilityLabel(let label):
             tester().waitForAbsenceOfView(withAccessibilityLabel: label)
         case .accessibilityID(let accessibilityID):
-            tester().waitForAbsenceOfView(withAccessibilityLabel: accessibilityID)
+            tester().waitForAbsenceOfView(withAccessibilityIdentifier: accessibilityID)
         default:
             unsupportedTest(file: file, line: line)
         }

--- a/Sencha/Extensions/XCTestCase+Sencha.swift
+++ b/Sencha/Extensions/XCTestCase+Sencha.swift
@@ -52,7 +52,7 @@ extension XCTestCase: Sencha {
         case .accessibilityLabel(let label):
             view = tester().waitForView(withAccessibilityLabel: label, traits: traits)
         case .accessibilityID(let accessibilityID):
-            view = tester().waitForView(withAccessibilityLabel: accessibilityID, traits: traits)
+            view = tester().waitForView(withAccessibilityIdentifier: accessibilityID)
         default:
             unsupportedTest(file: file, line: line)
         }


### PR DESCRIPTION
Use the correct method to match accesibilityIDs